### PR TITLE
allow public key and contract addresses to be supplied for nim codex operation

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -32,7 +32,7 @@ codex_discovery_port: 9000
 codex_listening_port: 9000
 
 # Ethereum public key for Codex node
-codex_eth_public_key: ''
+#nim_codex_eth_public_key: ~
 
 # Firewall
 codex_firewall_libp2p_open: true

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -31,10 +31,8 @@ codex_max_peers: 160
 codex_discovery_port: 9000
 codex_listening_port: 9000
 
-# Ethereum public key for Codex node and addresses of deployed Codex contracts
+# Ethereum public key for Codex node
 codex_eth_public_key: ''
-codex_eth_storage_contract: ''
-codex_eth_token_contract: ''
 
 # Firewall
 codex_firewall_libp2p_open: true

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -31,6 +31,11 @@ codex_max_peers: 160
 codex_discovery_port: 9000
 codex_listening_port: 9000
 
+# Ethereum public key for Codex node and addresses of deployed Codex contracts
+codex_eth_public_key: ''
+codex_eth_storage_contract: ''
+codex_eth_token_contract: ''
+
 # Firewall
 codex_firewall_libp2p_open: true
 codex_firewall_metrics_open: true

--- a/templates/beacon-node.service.j2
+++ b/templates/beacon-node.service.j2
@@ -20,6 +20,9 @@ ExecStart={{ codex_repo_path }}/build/codex \
     --max-peers={{ codex_max_peers }} \
     --api-port={{ codex_rest_port }} \
     --cache-size={{ codex_cache_size }} \
+    --eth-public-key={{ codex_eth_public_key }} \
+    --storage-contract-addr={{ codex_eth_storage_contract }} \
+    --token-contract-addr={{ codex_eth_token_contract }} \
 
 [Install]
 WantedBy=multi-user.target

--- a/templates/beacon-node.service.j2
+++ b/templates/beacon-node.service.j2
@@ -20,7 +20,7 @@ ExecStart={{ codex_repo_path }}/build/codex \
     --max-peers={{ codex_max_peers }} \
     --api-port={{ codex_rest_port }} \
     --cache-size={{ codex_cache_size }} \
-{% if codex_eth_public_key != "" %}
+{% if nim_codex_eth_public_key is defined %}
     --eth-public-key={{ codex_eth_public_key }} \
 {% endif %}
 

--- a/templates/beacon-node.service.j2
+++ b/templates/beacon-node.service.j2
@@ -20,9 +20,9 @@ ExecStart={{ codex_repo_path }}/build/codex \
     --max-peers={{ codex_max_peers }} \
     --api-port={{ codex_rest_port }} \
     --cache-size={{ codex_cache_size }} \
+{% if codex_eth_public_key != "" %}
     --eth-public-key={{ codex_eth_public_key }} \
-    --storage-contract-addr={{ codex_eth_storage_contract }} \
-    --token-contract-addr={{ codex_eth_token_contract }} \
+{% endif %}
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Anticipates support for these cli parameters being added to nim-dagger.

---

The PR is in draft because I need some input from @Menduist whether this is the correct way to do what he suggested in https://github.com/status-im/dagger-contracts/issues/9#issuecomment-1094245717.

Looking at [infra-codex/blob/tanguybranch/ansible/group_vars/all.yml#L64-L68](https://github.com/status-im/infra-codex/blob/tanguybranch/ansible/group_vars/all.yml#L64-L68), my understanding is that values supplied there can be used to override values for the same-named variables in infra-role-nim-codex. Is that correct?

If so, after doing the one-off deployment discussed in https://github.com/status-im/dagger-contracts/issues/9, we'd want the changes in this PR plus a PR for infra-codex where the contract addresses are supplied below L64-L68 linked above. Is that correct?

We can discuss it here or in https://github.com/status-im/dagger-contracts/issues/9, but we need to think about the token contract in relation to the storage contract, and the additional parameters for the storage contract. When testing against my local POA network I used `TestToken`'s address and other `Storage` constructor params from the tests for dagger-contracts, but maybe we want something different for our infra-codex testnet?

Then there's the matter of modifying nim-dagger to make use of the values supplied via cli params.